### PR TITLE
chore(MooLite): Cleanup already implemented TODOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MooLite is a free, open source [Milky Way Idle](https://www.milkywayidle.com/) c
 > Make sure you only install MooLite if you trust both TamperMonkey and MooLite not to steal your information.
 
 - Install [TamperMonkey](https://www.tampermonkey.net/) in the browser of your choice.
-- Install [MooLite](TODO) here.
+- Install [MooLite](https://github.com/Ishadijcks/Moolite/releases/latest/download/moolite.user.js) here.
 
 ## Development
 

--- a/src/MooLite/core/abilities/AbilityEffectType.ts
+++ b/src/MooLite/core/abilities/AbilityEffectType.ts
@@ -1,4 +1,1 @@
-export enum AbilityEffectType {
-    // TODO(@Isha): Add other effects
-    Damage = "/ability_effect_types/damage",
-}
+export enum AbilityEffectType {}

--- a/src/MooLite/core/combat/buffs/BuffHrid.ts
+++ b/src/MooLite/core/combat/buffs/BuffHrid.ts
@@ -1,4 +1,1 @@
-export enum BuffHrid {
-    // TODO(@Isha): Add all buffs here
-    Berserk = "/buff_uniques/berserk",
-}
+export enum BuffHrid {}

--- a/src/MooLite/core/combat/buffs/BuffTypeHrid.ts
+++ b/src/MooLite/core/combat/buffs/BuffTypeHrid.ts
@@ -1,4 +1,1 @@
-export enum BuffTypeHrid {
-    // TODO(@Isha): Add all types here
-    PhysicalAmplify = "/buff_types/physical_amplify",
-}
+export enum BuffTypeHrid {}

--- a/src/MooLite/core/inventory/Inventory.ts
+++ b/src/MooLite/core/inventory/Inventory.ts
@@ -39,7 +39,6 @@ export class Inventory {
     }
 
     updateCharacterItems(items: CharacterItem[], notify: boolean = true) {
-        // TODO(@Isha): Add events
         items.forEach((newItem) => {
             const itemInInventory = this._characterItems.find((item) => {
                 return item.id === newItem.id;

--- a/src/MooLite/core/inventory/items/ItemDetail.ts
+++ b/src/MooLite/core/inventory/items/ItemDetail.ts
@@ -10,7 +10,6 @@ export interface ItemDetail {
     categoryHrid: ItemCategoryHrid;
     consumableDetail: ConsumableDetail;
     description: string;
-    // TODO(@Isha): Or what?
     enhancementCosts: ItemAmount[] | null;
     equipmentDetail: EquipmentDetail;
     hrid: ItemHrid;


### PR DESCRIPTION
Previously I thought about adding what are now `detailMaps` as enums in the source. Now they are parsed from the `init_client_info`, much cleaner :)