### PR TITLE
Add .toLocaleString() formatting to numbers in the UI

### DIFF
--- a/src/MooLite/plugins/Leaderboard/LeaderboardPluginDisplay.vue
+++ b/src/MooLite/plugins/Leaderboard/LeaderboardPluginDisplay.vue
@@ -50,7 +50,7 @@ const lastUpdatedText = computed(() => {
                 <tr v-for="entry in playerData.skills">
                     <th class="text-left">{{ entry.name }}</th>
                     <th>{{ entry.level }}</th>
-                    <th>{{ entry.experience }}</th>
+                    <th>{{ entry.experience.toLocaleString() }}</th>
                     <th>{{ entry.rank }}</th>
                 </tr>
             </table>

--- a/src/MooLite/plugins/XpDetails/XpTrackerSkillDisplay.vue
+++ b/src/MooLite/plugins/XpDetails/XpTrackerSkillDisplay.vue
@@ -23,22 +23,22 @@ const actionsLeft = computed(() => {
             <div class="flex flex-col flex-1">
                 <span class="text-xxs">
                     <span class="text-ocean-200">XP Gained:</span>
-                    {{ Math.floor(skill.xpGained) }}
+                    {{ Math.floor(skill.xpGained).toLocaleString() }}
                 </span>
                 <span class="text-xxs">
                     <span class="text-ocean-200">XP/hr:</span>
-                    {{ Math.floor(skill.xpPerHour) }}
+                    {{ Math.floor(skill.xpPerHour).toLocaleString() }}
                 </span>
             </div>
 
             <div class="flex flex-col items-end">
                 <span class="text-xxs">
                     <span class="text-ocean-200">XP Left:</span>
-                    {{ Math.ceil(xpLeft) }}
+                    {{ Math.ceil(xpLeft).toLocaleString() }}
                 </span>
                 <span class="text-xxs">
                     <span class="text-ocean-200">Actions:</span>
-                    {{ Math.ceil(actionsLeft) }}
+                    {{ Math.ceil(actionsLeft).toLocaleString() }}
                 </span>
             </div>
         </div>


### PR DESCRIPTION
This makes it a lot easier to see bigger numbers (like 10s of millions of exp) and in a format the the user expects.