### PR TITLE
fix(MooLite): Fix UI inconsistencies

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,19 +35,19 @@ const setActiveTab = (index: number) => {
 
 <template>
     <div
-        class="overflow-scroll flex flex-col h-full bg-background-game text-dark-mode shadow-space-200 shadow-sm"
+        class="flex flex-col h-full shadow-sm overflow-clip bg-background-game text-dark-mode shadow-space-200"
         :class="{ 'w-64': activeTab !== -1 }"
     >
         <MooDivider class="border-b-4" />
 
         <div class="flex flex-row h-full">
-            <div v-if="activeTab > -1" class="flex flex-col flex-grow p-2">
+            <div v-if="activeTab > -1" class="flex flex-col flex-grow p-2 overflow-auto">
                 <PluginManagerDisplay v-if="activeTab === 0" :manager="pluginManager"></PluginManagerDisplay>
                 <div v-for="(tab, index) in tabs" v-show="index + 1 === activeTab">
                     <component v-bind:is="tab.componentName" :plugin="findPlugin(tab.pluginName)"></component>
                 </div>
             </div>
-            <div class="flex flex-col bg-divider shadow-space-200 shadow-sm">
+            <div class="flex flex-col h-full overflow-auto shrink-0 bg-divider ">
                 <template v-for="(tab, index) in tabs">
                     <PluginTabItem
                         v-if="index === 1"

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,7 @@ const setActiveTab = (index: number) => {
                     <component v-bind:is="tab.componentName" :plugin="findPlugin(tab.pluginName)"></component>
                 </div>
             </div>
-            <div class="flex flex-col h-full overflow-auto shrink-0 bg-divider ">
+            <div class="flex flex-col h-full overflow-auto shrink-0 bg-divider">
                 <template v-for="(tab, index) in tabs">
                     <PluginTabItem
                         v-if="index === 1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,10 +69,12 @@ const launchMooLite = () => {
             (() => {
                 const app = document.createElement("div");
                 const root = document.getElementById("root");
-                console.log(document.body.classList);
-                root?.append(app);
-                root?.style.setProperty("display", "flex");
-                root?.style.setProperty("flex-direction", "row");
+                if (root == null) {
+                    throw new Error("Could not append MooLite to the element with id 'root' as it does not exist");
+                }
+                root.append(app);
+                root.style.setProperty("display", "flex");
+                root.style.setProperty("flex-direction", "row");
                 return app;
             })()
         );

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,11 @@ const launchMooLite = () => {
         app.mount(
             (() => {
                 const app = document.createElement("div");
-                document.body.append(app);
+                const root = document.getElementById('root');
+                console.log(document.body.classList);
+                root?.append(app);
+                root?.style.setProperty("display", "flex");
+                root?.style.setProperty("flex-direction", "row");
                 return app;
             })()
         );

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ const launchMooLite = () => {
         app.mount(
             (() => {
                 const app = document.createElement("div");
-                const root = document.getElementById('root');
+                const root = document.getElementById("root");
                 console.log(document.body.classList);
                 root?.append(app);
                 root?.style.setProperty("display", "flex");

--- a/src/style.css
+++ b/src/style.css
@@ -2,14 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-    display: flex;
-}
-
 input {
-    @apply bg-white text-black;
+    @apply text-black bg-white;
 }
 
 select {
-    @apply bg-white text-black;
+    @apply text-black bg-white;
 }


### PR DESCRIPTION
In this PR I've done the following:

- Remove the body styling from the global CSS.
  - This was part of the cause of the whitespace issue. Before making this change, the whitespace would simply appear to the right of MooLite after I moved it's mount point.
- Moved the mount point from the body to the `#root` element as the last child.
- Changed `overflow-scroll` to `overflow-clip` on MooLites wrapping div.
  - This got rid of the invisible scroll bar at the bottom and side.
- Added `overflow-auto` to the icon gutter and plugin tab.
  - This gives us a clean look, but still allows us to scroll if necessary. Also fixes a bug where the entire MooLite UI scrolled if either of those containers overflowed.
- Added `shrink-0` to the icon gutter.
  - This fixed a bug where the gutter would sometimes be squished or pushed off screen if the plugin tab was too wide.

Closes #70