### PR TITLE
fix(LeaderboardPlugin): Update leaderboard to handle new structure introduced for tasks

### DIFF
--- a/src/MooLite/core/leaderboard/LeaderboardData.ts
+++ b/src/MooLite/core/leaderboard/LeaderboardData.ts
@@ -1,5 +1,5 @@
 export interface LeaderboardData {
     name: string;
-    level: number;
-    experience: number;
+    value1: number;
+    value2: number;
 }

--- a/src/MooLite/core/leaderboard/LeaderboardPlayerSummary.ts
+++ b/src/MooLite/core/leaderboard/LeaderboardPlayerSummary.ts
@@ -1,6 +1,8 @@
 import { LeaderboardSkill } from "src/MooLite/core/leaderboard/LeaderboardSkill";
+import { LeaderboardTaskPoints } from "src/MooLite/core/leaderboard/LeaderboardTaskPoints";
 
 export interface LeaderboardPlayerSummary {
     name: string;
     skills: LeaderboardSkill[];
+    taskPoints?: LeaderboardTaskPoints;
 }

--- a/src/MooLite/core/leaderboard/LeaderboardTaskPoints.ts
+++ b/src/MooLite/core/leaderboard/LeaderboardTaskPoints.ts
@@ -1,0 +1,5 @@
+export interface LeaderboardTaskPoints {
+    name: string;
+    taskPoints: number;
+    rank: number;
+}

--- a/src/MooLite/core/leaderboard/LeaderboardTopic.ts
+++ b/src/MooLite/core/leaderboard/LeaderboardTopic.ts
@@ -2,5 +2,6 @@ import { LeaderboardData } from "src/MooLite/core/leaderboard/LeaderboardData";
 
 export interface LeaderboardTopic {
     title: string;
+    columnNames: string[];
     data: LeaderboardData[];
 }

--- a/src/MooLite/plugins/Leaderboard/LeaderboardPluginDisplay.vue
+++ b/src/MooLite/plugins/Leaderboard/LeaderboardPluginDisplay.vue
@@ -3,6 +3,8 @@ import { computed, ref } from "vue";
 import { LeaderboardPlugin } from "src/MooLite/plugins/Leaderboard/LeaderboardPlugin";
 import MooDivider from "src/components/atoms/MooDivider.vue";
 import { DateFormatter } from "src/MooLite/util/DateFormatter";
+import ItemIcon from "src/components/atoms/ItemIcon.vue";
+import { ItemHrid } from "src/MooLite/core/inventory/ItemHrid";
 
 const props = defineProps<{
     plugin: LeaderboardPlugin;
@@ -52,6 +54,23 @@ const lastUpdatedText = computed(() => {
                     <th>{{ entry.level }}</th>
                     <th>{{ entry.experience.toLocaleString() }}</th>
                     <th>{{ entry.rank }}</th>
+                </tr>
+
+                <tr class="spacer h-6"></tr>
+
+                <tr class="pt-8" v-if="playerData.taskPoints">
+                    <th>Tasks</th>
+                    <th class="flex flex-row justify-center">
+                        <ItemIcon size="4" :item="'/items/task_token' as unknown as ItemHrid" />
+                    </th>
+                    <th></th>
+                    <th>🏆</th>
+                </tr>
+                <tr v-if="playerData.taskPoints">
+                    <th class="text-left">{{ playerData.taskPoints.name }}</th>
+                    <th>{{ playerData.taskPoints.taskPoints }}</th>
+                    <th></th>
+                    <th>{{ playerData.taskPoints.rank }}</th>
                 </tr>
             </table>
             <span v-else class="italic text-xs" v-if="selectedName"

--- a/src/components/atoms/ItemAmountDisplay.vue
+++ b/src/components/atoms/ItemAmountDisplay.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 
 <template>
     <div class="flex flex-col items-center" :title="name">
-        <ItemIcon class="w-6 h-6" :item="itemAmount.itemHrid"></ItemIcon>
+        <ItemIcon :item="itemAmount.itemHrid"></ItemIcon>
         <span>{{ itemAmount.count }}</span>
     </div>
 </template>

--- a/src/components/atoms/ItemIcon.vue
+++ b/src/components/atoms/ItemIcon.vue
@@ -4,18 +4,19 @@ import { ItemHrid } from "src/MooLite/core/inventory/ItemHrid";
 
 const props = defineProps<{
     item: ItemHrid;
+    size: string;
 }>();
 
 const imgUrl = computed(() => {
     const split = (props.item as unknown as string).split("/");
     const itemPostfix = split[split.length - 1];
     // TODO(@Isha): Research how these CDN resource urls are generated
-    return `/static/media/items_sprite.20cec8ed.svg#${itemPostfix}`;
+    return `/static/media/items_sprite.951ef1ec.svg#${itemPostfix}`;
 });
 </script>
 
 <template>
-    <svg class="w-8 h-8">
+    <svg :class="'w-' + (size ?? 8) + ' h-' + (size ?? 8)">
         <use :href="imgUrl"></use>
     </svg>
 </template>

--- a/src/components/atoms/ItemIcon.vue
+++ b/src/components/atoms/ItemIcon.vue
@@ -2,10 +2,14 @@
 import { computed } from "vue";
 import { ItemHrid } from "src/MooLite/core/inventory/ItemHrid";
 
-const props = defineProps<{
+export interface Props {
     item: ItemHrid;
-    size: string;
-}>();
+    size?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    size: "8",
+});
 
 const imgUrl = computed(() => {
     const split = (props.item as unknown as string).split("/");
@@ -16,7 +20,7 @@ const imgUrl = computed(() => {
 </script>
 
 <template>
-    <svg :class="'w-' + (size ?? 8) + ' h-' + (size ?? 8)">
+    <svg :class="'w-' + size + ' h-' + size">
         <use :href="imgUrl"></use>
     </svg>
 </template>


### PR DESCRIPTION
The current implementation does not scale to various types of leaderboards, but it works for now. If another type is introduced it would be better to refactor it such that we can predefine a set of categories that will be parsed and rendered correctly automatically