### PR TITLE
Add `text-dark-mode` to `select` and `input` tags

### DIFF
--- a/src/MooLite/plugins/ItemFinder/ItemFinderPluginDisplay.vue
+++ b/src/MooLite/plugins/ItemFinder/ItemFinderPluginDisplay.vue
@@ -60,7 +60,7 @@ const formatDropRate = (percentage: number, digits: number = 3, threshold: numbe
     <div class="flex flex-col">
         <span class="text-center">{{ plugin.name }}</span>
         <MooDivider class="mb-2" />
-        <select v-model="selectedHrid" class="bg-divider p-2">
+        <select v-model="selectedHrid" class="bg-divider p-2 text-dark-mode">
             <option v-for="option in options" :value="option.value" class="bg-divider">
                 {{ option.text }}
             </option>

--- a/src/MooLite/plugins/LootSimulator/LootSimulatorPluginDisplay.vue
+++ b/src/MooLite/plugins/LootSimulator/LootSimulatorPluginDisplay.vue
@@ -30,7 +30,7 @@ const simulate = () => {
 <template>
     <div class="flex flex-col">
         <span>Loot Simulator</span>
-        <select v-model="selectedHrid" class="bg-divider">
+        <select v-model="selectedHrid" class="bg-divider text-dark-mode">
             <option v-for="option in options" :value="option.value" class="bg-divider">
                 {{ option.text }}
             </option>

--- a/src/components/plugins/config/PluginConfigDisplay.vue
+++ b/src/components/plugins/config/PluginConfigDisplay.vue
@@ -24,14 +24,14 @@ const emit = defineEmits(["onConfigChange"]);
             v-if="config.type === PluginConfigType.Text"
             type="text"
             v-model="config.value"
-            class="bg-divider w-24C"
+            class="bg-divider w-24C text-dark-mode"
         />
 
         <select
             v-if="config.type === PluginConfigType.Choice"
             v-model="config.value"
             @change="emit('onConfigChange')"
-            class="bg-divider w-24"
+            class="bg-divider w-24 text-dark-mode"
         >
             {{
                 options


### PR DESCRIPTION
When this change is applied, currently existing `select` tags will be styled using `text-dark-mode` to match the rest of the text in the application. This is significantly more readable in the default theme.

The same style is also applied to text inputs in the config panel. i.e. Chat Notifier config.

| Before  | After |
| --- | --- |
| ![image](https://github.com/Ishadijcks/MooLite/assets/9394863/05c26b15-f3fc-4db0-801d-734963d9bbda)  | ![image](https://github.com/Ishadijcks/MooLite/assets/9394863/089d1c0d-7679-494e-99b8-43aaec4b2a1c)  |