### PR TITLE
Refactor message file structure

### DIFF
--- a/src/MooLite/core/Game.ts
+++ b/src/MooLite/core/Game.ts
@@ -3,13 +3,13 @@ import { Chat } from "src/MooLite/core/chat/Chat";
 import { ActionQueue } from "src/MooLite/core/actions/ActionQueue";
 import { Inventory } from "src/MooLite/core/inventory/Inventory";
 import { Notifier } from "src/MooLite/core/notifications/Notifier";
-import { InitClientInfoMessage } from "src/MooLite/core/server/messages/InitClientInfo";
 import { Abilities } from "src/MooLite/core/abilities/Abilities";
 import { Combat } from "src/MooLite/core/combat/Combat";
 import { Leaderboard } from "src/MooLite/core/leaderboard/Leaderboard";
 import { Equipment } from "src/MooLite/core/equipment/Equipment";
 import { LootBoxes } from "src/MooLite/core/lootboxes/LootBoxes";
 import { Character } from "src/MooLite/core/character/Character";
+import { InitClientInfoMessage } from "./messages/server/messages/InitClientInfo";
 
 export class Game {
     gameVersion: string;

--- a/src/MooLite/core/MooLite.ts
+++ b/src/MooLite/core/MooLite.ts
@@ -1,28 +1,32 @@
 import { PluginManager } from "src/MooLite/core/plugins/PluginManager";
 import { MooSocket } from "src/MooLite/core/MooSocket";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
-import { ActionCompletedParser } from "src/MooLite/core/server/messages/ActionCompleted";
 import { Game } from "src/MooLite/core/Game";
-import { ChatMessageReceivedParser } from "src/MooLite/core/server/messages/ChatMessageReceived";
-import { ActivePlayerCountUpdatedParser } from "src/MooLite/core/server/messages/ActivePlayerCountUpdated";
-import { ConsumableSlotsUpdatedParser } from "src/MooLite/core/server/messages/ConsumableSlotsUpdated";
-import { ActionsUpdatedParser } from "src/MooLite/core/server/messages/ActionsUpdated";
-import { InitCharacterInfoParser } from "src/MooLite/core/server/messages/InitCharacterInfoParser";
-import { InfoParser } from "src/MooLite/core/server/messages/Info";
-import { LeaderboardInfoUpdatedParser } from "src/MooLite/core/server/messages/LeaderboardInfoUpdated";
-import { PingParser } from "src/MooLite/core/server/clientmessages/Ping";
-import { ClientMessage } from "src/MooLite/core/server/clientmessages/ClientMessage";
-import { PongParser } from "src/MooLite/core/server/messages/Pong";
 import { LocalStorage } from "src/MooLite/util/LocalStorage";
 import { MooLiteSaveData } from "src/MooLite/core/MooLiteSaveData";
-import { CombatTriggersUpdatedParser } from "src/MooLite/core/server/messages/CombatTriggersUpdated";
-import { CharacterStatsUpdatedParser } from "src/MooLite/core/server/messages/CharacterStatsUpdated";
-import { EquipmentBuffsUpdatedParser } from "src/MooLite/core/server/messages/EquipmentBuffsUpdated";
-import { ItemsUpdatedParser } from "src/MooLite/core/server/messages/ItemsUpdated";
-import { LootOpenedParser } from "src/MooLite/core/server/messages/LootOpened";
-import { AbilitiesUpdatedParser } from "src/MooLite/core/server/messages/AbilitiesUpdated";
-
+import { InitClientInfoParser } from "./messages/server/messages/InitClientInfo";
+import { MessageParser } from "./messages/MessageParser";
+import { ClientMessage } from "./messages/client/ClientMessage";
+import { GetMarketItemOrderBooksParser } from "./messages/client/messages/GetMarketItemOrderBooks";
+import { PingParser } from "./messages/client/messages/Ping";
+import { ServerMessage } from "./messages/server/ServerMessage";
+import { AbilitiesUpdatedParser } from "./messages/server/messages/AbilitiesUpdated";
+import { ActionCompletedParser } from "./messages/server/messages/ActionCompleted";
+import { ActionsUpdatedParser } from "./messages/server/messages/ActionsUpdated";
+import { ActivePlayerCountUpdatedParser } from "./messages/server/messages/ActivePlayerCountUpdated";
+import { CharacterStatsUpdatedParser } from "./messages/server/messages/CharacterStatsUpdated";
+import { ChatMessageReceivedParser } from "./messages/server/messages/ChatMessageReceived";
+import { CombatTriggersUpdatedParser } from "./messages/server/messages/CombatTriggersUpdated";
+import { CombatUnitsInBattleUpdatedMessageParser } from "./messages/server/messages/CombatUnitsInBattleUpdated";
+import { ConsumableSlotsUpdatedParser } from "./messages/server/messages/ConsumableSlotsUpdated";
+import { EquipmentBuffsUpdatedParser } from "./messages/server/messages/EquipmentBuffsUpdated";
+import { InfoParser } from "./messages/server/messages/Info";
+import { InitCharacterInfoParser } from "./messages/server/messages/InitCharacterInfo";
+import { ItemsUpdatedParser } from "./messages/server/messages/ItemsUpdated";
+import { LeaderboardInfoUpdatedParser } from "./messages/server/messages/LeaderboardInfoUpdated";
+import { LootOpenedParser } from "./messages/server/messages/LootOpened";
+import { MarketItemorderBooksUpdated } from "./messages/server/messages/MarketItemOrderBooksUpdated";
+import { NewBattleMessageParser } from "./messages/server/messages/NewBattle";
+import { PongParser } from "./messages/server/messages/Pong";
 export class MooLite {
     pluginManager: PluginManager;
     mooSocket: MooSocket;
@@ -31,6 +35,7 @@ export class MooLite {
 
     messageParsers: MessageParser[] = [
         // Server messages
+        new InitClientInfoParser(),
         new InitCharacterInfoParser(),
         new PongParser(),
 
@@ -41,15 +46,19 @@ export class MooLite {
         new ConsumableSlotsUpdatedParser(),
         new InfoParser(),
         new CombatTriggersUpdatedParser(),
+        new NewBattleMessageParser(),
+        new CombatUnitsInBattleUpdatedMessageParser(),
         new LeaderboardInfoUpdatedParser(),
         new LootOpenedParser(),
         new CharacterStatsUpdatedParser(),
         new EquipmentBuffsUpdatedParser(),
         new ItemsUpdatedParser(),
         new AbilitiesUpdatedParser(),
+        new MarketItemorderBooksUpdated(),
 
         // Client messages
         new PingParser(),
+        new GetMarketItemOrderBooksParser(),
     ];
 
     private _interval: NodeJS.Timeout;
@@ -159,13 +168,13 @@ export class MooLite {
         const parser = this.messageParsers.find((parser) => {
             return parser.canParse(message);
         });
+
         if (!parser) {
-            if (!isClientMessage) {
-                console.warn(`Unhandled message type ${message.type}`);
-                console.log(message);
-            }
-            return;
+            return isClientMessage
+                ? console.debug(`Unhandled client message type: ${message.type}`, message)
+                : console.warn(`Unhandled server message type: ${message.type}`, message);
         }
+
         parser.apply(message, this.game);
     }
 }

--- a/src/MooLite/core/MooSocket.ts
+++ b/src/MooLite/core/MooSocket.ts
@@ -1,9 +1,9 @@
 import { SimpleEventDispatcher } from "strongly-typed-events";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { InitClientInfoMessage } from "src/MooLite/core/server/messages/InitClientInfo";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { ClientMessage } from "src/MooLite/core/server/clientmessages/ClientMessage";
 import { unsafeWindow } from "$";
+import { ServerMessage } from "./messages/server/ServerMessage";
+import { ClientMessage } from "./messages/client/ClientMessage";
+import { InitClientInfoMessage } from "./messages/server/messages/InitClientInfo";
+import { ServerMessageType } from "./messages/server/ServerMessageType";
 
 export class MooSocket extends WebSocket {
     private _onServerMessage = new SimpleEventDispatcher<ServerMessage>();

--- a/src/MooLite/core/leaderboard/Leaderboard.ts
+++ b/src/MooLite/core/leaderboard/Leaderboard.ts
@@ -36,8 +36,6 @@ export class Leaderboard {
             return null;
         }
 
-        console.log(this.leaderboardList);
-
         const skills: LeaderboardSkill[] = this.getSkillLeaderboards().flatMap((value) => {
             const playerEntry = value.data.find((entry) => entry.name.toLowerCase() === name.toLowerCase());
             if (!playerEntry) {

--- a/src/MooLite/core/messages/MessageParser.ts
+++ b/src/MooLite/core/messages/MessageParser.ts
@@ -1,8 +1,8 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
 import { Game } from "src/MooLite/core/Game";
-import { ClientMessageType } from "src/MooLite/core/server/clientmessages/ClientMessageType";
-import { ClientMessage } from "src/MooLite/core/server/clientmessages/ClientMessage";
+import { ServerMessageType } from "./server/ServerMessageType";
+import { ClientMessage } from "./client/ClientMessage";
+import { ClientMessageType } from "./client/ClientMessageType";
+import { ServerMessage } from "./server/ServerMessage";
 
 export abstract class MessageParser {
     abstract type: ServerMessageType | ClientMessageType;

--- a/src/MooLite/core/messages/NoopMessageParser.ts
+++ b/src/MooLite/core/messages/NoopMessageParser.ts
@@ -1,0 +1,8 @@
+import { MessageParser } from "./MessageParser";
+import { ServerMessage } from "./server/ServerMessage";
+
+export abstract class NoopMessageParser extends MessageParser {
+    apply(message: ServerMessage): void {
+        console.debug(`Parsing ${this.type} message`, message);
+    }
+}

--- a/src/MooLite/core/messages/client/ClientMessage.ts
+++ b/src/MooLite/core/messages/client/ClientMessage.ts
@@ -1,0 +1,5 @@
+import { ClientMessageType } from "src/MooLite/core/server/ClientMessageType";
+
+export interface ClientMessage {
+    type: ClientMessageType;
+}

--- a/src/MooLite/core/messages/client/ClientMessage.ts
+++ b/src/MooLite/core/messages/client/ClientMessage.ts
@@ -1,4 +1,4 @@
-import { ClientMessageType } from "src/MooLite/core/server/ClientMessageType";
+import { ClientMessageType } from "./ClientMessageType";
 
 export interface ClientMessage {
     type: ClientMessageType;

--- a/src/MooLite/core/messages/client/ClientMessageType.ts
+++ b/src/MooLite/core/messages/client/ClientMessageType.ts
@@ -1,0 +1,4 @@
+export enum ClientMessageType {
+    Ping = "/character_tasks/ping",
+    GetMarketItemOrderBooks = "/character_tasks/get_market_item_order_books",
+}

--- a/src/MooLite/core/messages/client/messages/GetMarketItemOrderBooks.ts
+++ b/src/MooLite/core/messages/client/messages/GetMarketItemOrderBooks.ts
@@ -1,0 +1,16 @@
+import { Game } from "src/MooLite/core/Game";
+import { ClientMessageType } from "../ClientMessageType";
+import { ClientMessage } from "../ClientMessage";
+import { MessageParser } from "../../MessageParser";
+
+export interface GetMarketItemOrderBooksMessage extends ClientMessage {
+    type: ClientMessageType.GetMarketItemOrderBooks;
+}
+
+export class GetMarketItemOrderBooksParser extends MessageParser {
+    type = ClientMessageType.GetMarketItemOrderBooks;
+
+    apply(message: GetMarketItemOrderBooksMessage, game: Game): void {
+        console.debug(this.type, { message });
+    }
+}

--- a/src/MooLite/core/messages/client/messages/Ping.ts
+++ b/src/MooLite/core/messages/client/messages/Ping.ts
@@ -1,7 +1,7 @@
-import { ClientMessage } from "src/MooLite/core/server/clientmessages/ClientMessage";
-import { ClientMessageType } from "src/MooLite/core/server/clientmessages/ClientMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
+import { ClientMessageType } from "../ClientMessageType";
+import { MessageParser } from "../../MessageParser";
+import { ClientMessage } from "../ClientMessage";
 
 export interface PingMessage extends ClientMessage {
     type: ClientMessageType.Ping;

--- a/src/MooLite/core/messages/server/ServerMessage.ts
+++ b/src/MooLite/core/messages/server/ServerMessage.ts
@@ -1,0 +1,5 @@
+import { ServerMessageType } from "./ServerMessageType";
+
+export interface ServerMessage {
+    type: ServerMessageType;
+}

--- a/src/MooLite/core/messages/server/ServerMessageType.ts
+++ b/src/MooLite/core/messages/server/ServerMessageType.ts
@@ -11,6 +11,7 @@ export enum ServerMessageType {
 
     CharacterStatsUpdated = "character_stats_updated",
     EquipmentBuffsUpdated = "equipment_buffs_updated",
+    CommunityBuffsUpdated = "community_buffs_updated",
     ItemsUpdated = "items_updated",
 
     LootOpened = "loot_opened",
@@ -26,7 +27,12 @@ export enum ServerMessageType {
     // Combat
     CombatTriggersUpdated = "combat_triggers_updated",
     AbilitiesUpdated = "abilities_updated",
+    CombatUnitsInBattleUpdated = "combat_units_in_battle_updated",
+    NewBattle = "new_battle",
 
     // Leaderboard
     LeaderboardInfoUpdated = "leaderboard_info_updated",
+
+    // Marketplace
+    MarketItemorderBooksUpdated = "market_item_order_books_updated",
 }

--- a/src/MooLite/core/messages/server/messages/AbilitiesUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/AbilitiesUpdated.ts
@@ -1,8 +1,8 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
-import { Game } from "src/MooLite/core/Game";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
 import { CharacterAbility } from "src/MooLite/core/abilities/CharacterAbility";
+import { ServerMessageType } from "../ServerMessageType";
+import { ServerMessage } from "../ServerMessage";
+import { MessageParser } from "../../MessageParser";
+import { Game } from "src/MooLite/core/Game";
 
 export interface AbilitiesUpdatedMessage extends ServerMessage {
     type: ServerMessageType.AbilitiesUpdated;

--- a/src/MooLite/core/messages/server/messages/ActionCompleted.ts
+++ b/src/MooLite/core/messages/server/messages/ActionCompleted.ts
@@ -1,11 +1,11 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { CharacterSkill } from "src/MooLite/core/skills/CharacterSkill";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
 import { CharacterAction } from "src/MooLite/core/actions/CharacterAction";
 import { CharacterItem } from "src/MooLite/core/inventory/CharacterItem";
 import { CharacterAbility } from "src/MooLite/core/abilities/CharacterAbility";
+import { CharacterSkill } from "src/MooLite/core/skills/CharacterSkill";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 
 export interface ActionCompletedMessage extends ServerMessage {
     type: ServerMessageType.ActionCompleted;

--- a/src/MooLite/core/messages/server/messages/ActionsUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/ActionsUpdated.ts
@@ -1,6 +1,6 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { CharacterAction } from "src/MooLite/core/actions/CharacterAction";
 

--- a/src/MooLite/core/messages/server/messages/ActivePlayerCountUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/ActivePlayerCountUpdated.ts
@@ -1,7 +1,7 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 
 export interface ActivePlayerCountUpdatedMessage extends ServerMessage {
     type: ServerMessageType.ActivePlayerCountUpdated;

--- a/src/MooLite/core/messages/server/messages/CharacterStatsUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/CharacterStatsUpdated.ts
@@ -1,6 +1,6 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { NonCombatStats } from "src/MooLite/core/equipment/NonCombatStats";
 import { CombatUnit } from "src/MooLite/core/combat/CombatUnit";

--- a/src/MooLite/core/messages/server/messages/ChatMessageReceived.ts
+++ b/src/MooLite/core/messages/server/messages/ChatMessageReceived.ts
@@ -1,9 +1,9 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
 import { ChatChannelTypeHrid } from "src/MooLite/core/chat/ChatChannelTypeHrid";
 import { ChatIconHrid } from "src/MooLite/core/chat/ChatIconHrid";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 
 export interface ChatMessageReceived extends ServerMessage {
     type: ServerMessageType.ChatMessageReceived;

--- a/src/MooLite/core/messages/server/messages/CombatTriggersUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/CombatTriggersUpdated.ts
@@ -1,6 +1,6 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { AbilityHrid } from "src/MooLite/core/abilities/AbilityHrid";
 import { CombatTrigger } from "src/MooLite/core/combat/triggers/CombatTrigger";

--- a/src/MooLite/core/messages/server/messages/CombatUnitsInBattleUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/CombatUnitsInBattleUpdated.ts
@@ -1,0 +1,6 @@
+import { NoopMessageParser } from "../../NoopMessageParser";
+import { ServerMessageType } from "../ServerMessageType";
+
+export class CombatUnitsInBattleUpdatedMessageParser extends NoopMessageParser {
+    type = ServerMessageType.CombatUnitsInBattleUpdated;
+}

--- a/src/MooLite/core/messages/server/messages/CommunityBuffsUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/CommunityBuffsUpdated.ts
@@ -1,0 +1,6 @@
+import { NoopMessageParser } from "../../NoopMessageParser";
+import { ServerMessageType } from "../ServerMessageType";
+
+export class CommunityBuffsUpdatedMessageParser extends NoopMessageParser {
+    type = ServerMessageType.CommunityBuffsUpdated;
+}

--- a/src/MooLite/core/messages/server/messages/ConsumableSlotsUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/ConsumableSlotsUpdated.ts
@@ -1,6 +1,6 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { ActionTypeHrid } from "src/MooLite/core/actions/ActionTypeHrid";
 import { CharacterConsumable } from "src/MooLite/core/inventory/items/CharacterConsumable";

--- a/src/MooLite/core/messages/server/messages/EquipmentBuffsUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/EquipmentBuffsUpdated.ts
@@ -1,6 +1,6 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { ActionTypeHrid } from "src/MooLite/core/actions/ActionTypeHrid";
 import { EquipmentActionTypeBuff } from "src/MooLite/core/equipment/EquipmentActionTypeBuff";

--- a/src/MooLite/core/messages/server/messages/Info.ts
+++ b/src/MooLite/core/messages/server/messages/Info.ts
@@ -1,7 +1,7 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
 
 export interface InfoMessage extends ServerMessage {
     type: ServerMessageType.Info;

--- a/src/MooLite/core/messages/server/messages/InitCharacterInfo.ts
+++ b/src/MooLite/core/messages/server/messages/InitCharacterInfo.ts
@@ -1,7 +1,4 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
 import { CharacterAction } from "src/MooLite/core/actions/CharacterAction";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
 import { CharacterItem } from "src/MooLite/core/inventory/CharacterItem";
 import { CharacterSkill } from "src/MooLite/core/skills/CharacterSkill";
@@ -17,6 +14,9 @@ import { NonCombatStats } from "src/MooLite/core/equipment/NonCombatStats";
 import { Character } from "src/MooLite/core/character/Character";
 import { ChatMessage } from "src/MooLite/core/chat/ChatMessage";
 import { CharacterDetail } from "src/MooLite/core/character/CharacterDetail";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 
 export interface InitCharacterInfoMessage extends ServerMessage {
     type: ServerMessageType.InitCharacterInfo;
@@ -39,7 +39,6 @@ export class InitCharacterInfoParser extends MessageParser {
     type = ServerMessageType.InitCharacterInfo;
 
     apply(message: InitCharacterInfoMessage, game: Game): void {
-        console.log(message);
         game.abilities.updateCharacterAbilities(message.characterAbilities, false);
         game.abilities.updateCombatTriggers(message.abilityCombatTriggersMap);
         game.actionQueue.updateActions(message.characterActions);

--- a/src/MooLite/core/messages/server/messages/InitClientInfo.ts
+++ b/src/MooLite/core/messages/server/messages/InitClientInfo.ts
@@ -1,6 +1,3 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
 import { AbilityHrid } from "src/MooLite/core/abilities/AbilityHrid";
 import { AbilityDetail } from "src/MooLite/core/abilities/AbilityDetail";
@@ -30,6 +27,9 @@ import { EquipmentTypeHrid } from "src/MooLite/core/equipment/EquipmentTypeHrid"
 import { EquipmentTypeDetail } from "src/MooLite/core/equipment/EquipmentTypeDetail";
 import { ItemLocationHrid } from "src/MooLite/core/inventory/ItemLocationHrid";
 import { ItemLocationDetail } from "src/MooLite/core/inventory/ItemLocationDetail";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 
 export interface InitClientInfoMessage extends ServerMessage {
     type: ServerMessageType.InitClientInfo;

--- a/src/MooLite/core/messages/server/messages/ItemsUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/ItemsUpdated.ts
@@ -1,6 +1,6 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { CharacterItem } from "src/MooLite/core/inventory/CharacterItem";
 

--- a/src/MooLite/core/messages/server/messages/LeaderboardInfoUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/LeaderboardInfoUpdated.ts
@@ -1,7 +1,7 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
 import { LeaderboardTopic } from "src/MooLite/core/leaderboard/LeaderboardTopic";
 
 export interface LeaderboardInfoUpdatedMessage extends ServerMessage {

--- a/src/MooLite/core/messages/server/messages/LootOpened.ts
+++ b/src/MooLite/core/messages/server/messages/LootOpened.ts
@@ -1,6 +1,6 @@
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 import { Game } from "src/MooLite/core/Game";
 import { CharacterItem } from "src/MooLite/core/inventory/CharacterItem";
 

--- a/src/MooLite/core/messages/server/messages/MarketItemOrderBooksUpdated.ts
+++ b/src/MooLite/core/messages/server/messages/MarketItemOrderBooksUpdated.ts
@@ -1,0 +1,6 @@
+import { NoopMessageParser } from "../../NoopMessageParser";
+import { ServerMessageType } from "../ServerMessageType";
+
+export class MarketItemorderBooksUpdated extends NoopMessageParser {
+    type = ServerMessageType.MarketItemorderBooksUpdated;
+}

--- a/src/MooLite/core/messages/server/messages/NewBattle.ts
+++ b/src/MooLite/core/messages/server/messages/NewBattle.ts
@@ -1,0 +1,6 @@
+import { NoopMessageParser } from "../../NoopMessageParser";
+import { ServerMessageType } from "../ServerMessageType";
+
+export class NewBattleMessageParser extends NoopMessageParser {
+    type = ServerMessageType.NewBattle;
+}

--- a/src/MooLite/core/messages/server/messages/Pong.ts
+++ b/src/MooLite/core/messages/server/messages/Pong.ts
@@ -1,7 +1,7 @@
-import { MessageParser } from "src/MooLite/core/server/MessageParser";
 import { Game } from "src/MooLite/core/Game";
-import { ServerMessage } from "src/MooLite/core/server/ServerMessage";
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
+import { MessageParser } from "../../MessageParser";
+import { ServerMessage } from "../ServerMessage";
+import { ServerMessageType } from "../ServerMessageType";
 
 export interface PongMessage extends ServerMessage {
     type: ServerMessageType.Pong;

--- a/src/MooLite/core/notifications/Notifier.ts
+++ b/src/MooLite/core/notifications/Notifier.ts
@@ -1,7 +1,7 @@
-import { InfoMessage } from "src/MooLite/core/server/messages/Info";
 import { SimpleEventDispatcher } from "strongly-typed-events";
 import { MooNotification } from "src/MooLite/core/notifications/MooNotification";
 import { NotificationType } from "src/MooLite/core/notifications/NotificationType";
+import { InfoMessage } from "../messages/server/messages/Info";
 
 export class Notifier {
     private _onNotification = new SimpleEventDispatcher<MooNotification>();

--- a/src/MooLite/core/server/ServerMessage.ts
+++ b/src/MooLite/core/server/ServerMessage.ts
@@ -1,5 +1,0 @@
-import { ServerMessageType } from "src/MooLite/core/server/ServerMessageType";
-
-export interface ServerMessage {
-    type: ServerMessageType;
-}

--- a/src/MooLite/core/server/clientmessages/ClientMessage.ts
+++ b/src/MooLite/core/server/clientmessages/ClientMessage.ts
@@ -1,5 +1,0 @@
-import { ClientMessageType } from "src/MooLite/core/server/clientmessages/ClientMessageType";
-
-export interface ClientMessage {
-    type: ClientMessageType;
-}

--- a/src/MooLite/core/server/clientmessages/ClientMessageType.ts
+++ b/src/MooLite/core/server/clientmessages/ClientMessageType.ts
@@ -1,3 +1,0 @@
-export enum ClientMessageType {
-    Ping = "/character_tasks/ping",
-}


### PR DESCRIPTION
When this change is applied,

* the server message type is moved into a messages folder, and the
  client messages folder also exists in its own subdirectory instead
  of a subdirectory of server messages

* adds a NoopMessageParser which will log the received message instead
  of warning about an unhandled message. This will allow warnings to be
  cut down while still keeping track of messages which aren't fully handled,
  and also allow some message types to be ignored.

* adds Noop handlers for NewBattle, CombatUnitsInBattleUpdated,
  CommunityBuffsUpdated, and MarketItemOrderBooksUpdated. This is
  just to work towards message completion