### PR TITLE
Add support for multiple tracked items

### DIFF
--- a/src/MooLite/plugins/LootNotifier/AbilityNotifierOptions.ts
+++ b/src/MooLite/plugins/LootNotifier/AbilityNotifierOptions.ts
@@ -1,0 +1,5 @@
+export enum AbilityNotifierOptions {
+    Never = "never",
+    New = "new",
+    Always = "always",
+}

--- a/src/MooLite/plugins/LootNotifier/LootNotifierPluginDisplay.vue
+++ b/src/MooLite/plugins/LootNotifier/LootNotifierPluginDisplay.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import MooDivider from "src/components/atoms/MooDivider.vue";
+import { LootNotifierPlugin } from "./LootNotifierPlugin";
+import { AbilityNotifierOptions } from "./AbilityNotifierOptions";
+
+const props = defineProps<{
+    plugin: LootNotifierPlugin;
+}>();
+
+const highlightAbilitiesOptions = [
+    { text: "New", value: AbilityNotifierOptions.New },
+    { text: "Never", value: AbilityNotifierOptions.Never },
+    { text: "Always", value: AbilityNotifierOptions.Always },
+]
+
+const itemOptions = computed(() => {
+    return props.plugin.allItems.map((item) => {
+        return {
+            text: item.name,
+            value: item.hrid,
+        };
+    });
+});
+
+function selectedHridOnChange(event: any) {
+    props.plugin.addHighlightedItemHrid(event.target.value)
+}
+
+</script>
+
+<template>
+    <div class="flex flex-col">
+        <span class="text-center">{{ plugin.name }}</span>
+
+        <MooDivider class="mb-2" />
+
+        <div class="flex flex-row justify-between">
+            <p>Highlight abilities</p>
+            <select
+                v-model="plugin.highlightAbilities"
+                class="bg-divider w-24 text-dark-mode"
+            >
+                <option v-for="option in highlightAbilitiesOptions" :value="option.value" class="bg-divider">
+                    {{ option.text }}
+                </option>
+            </select>
+        </div>
+
+        <br />
+
+        <div class="flex flex-row justify-between">
+            <p>Item</p>
+            <select @change="selectedHridOnChange($event)" class="bg-divider text-dark-mode">
+                <option v-for="option in itemOptions" :value="option.value" class="bg-divider">
+                    {{ option.text }}
+                </option>
+            </select>
+        </div>
+
+        <br />
+
+        <p>Tracked items</p>
+
+        <div v-for="itemHrid in props.plugin.highlightedItemHrids" class="flex flex-row justify-between">
+            <p class="font-thin">
+                {{ itemOptions.find(option => (option.value as any) === itemHrid)?.text ?? 'Unknown' }}
+            </p>
+            <button @click="plugin.removeHighlightedItemHrid(itemHrid)">🗑️</button>
+        </div>
+    </div>
+</template>

--- a/src/MooLite/plugins/LootNotifier/LootNotifierPluginDisplay.vue
+++ b/src/MooLite/plugins/LootNotifier/LootNotifierPluginDisplay.vue
@@ -12,7 +12,7 @@ const highlightAbilitiesOptions = [
     { text: "New", value: AbilityNotifierOptions.New },
     { text: "Never", value: AbilityNotifierOptions.Never },
     { text: "Always", value: AbilityNotifierOptions.Always },
-]
+];
 
 const itemOptions = computed(() => {
     return props.plugin.allItems.map((item) => {
@@ -24,9 +24,8 @@ const itemOptions = computed(() => {
 });
 
 function selectedHridOnChange(event: any) {
-    props.plugin.addHighlightedItemHrid(event.target.value)
+    props.plugin.addHighlightedItemHrid(event.target.value);
 }
-
 </script>
 
 <template>
@@ -37,10 +36,7 @@ function selectedHridOnChange(event: any) {
 
         <div class="flex flex-row justify-between">
             <p>Highlight abilities</p>
-            <select
-                v-model="plugin.highlightAbilities"
-                class="bg-divider w-24 text-dark-mode"
-            >
+            <select v-model="plugin.highlightAbilities" class="bg-divider w-24 text-dark-mode">
                 <option v-for="option in highlightAbilitiesOptions" :value="option.value" class="bg-divider">
                     {{ option.text }}
                 </option>
@@ -64,7 +60,7 @@ function selectedHridOnChange(event: any) {
 
         <div v-for="itemHrid in props.plugin.highlightedItemHrids" class="flex flex-row justify-between">
             <p class="font-thin">
-                {{ itemOptions.find(option => (option.value as any) === itemHrid)?.text ?? 'Unknown' }}
+                {{ itemOptions.find((option) => (option.value as any) === itemHrid)?.text ?? "Unknown" }}
             </p>
             <button @click="plugin.removeHighlightedItemHrid(itemHrid)">🗑️</button>
         </div>


### PR DESCRIPTION
## Notes

Apologies if this is sloppy, I've never used Vue before so I'm not really aware of what the best practices are. This was just a quick change based on a [Discord request](https://discord.com/channels/891160051459436574/992941001377337384/1204045944581259264)

## Overview

When applied, this change will update the LootNotifierPlugin to support multiple tracked items. Instead of having a configuration pane using predefined config options, it will now have its own plugin window where multiple items can be selected for tracking.

I chose to implement this in its own panel instead of as a multi-select for readability and clarity since multi-select inputs are notoriously hard to track for long lists.

## Testing Instructions

* Enable Loot Notifier plugin

* Use `Item` select box to select items to track
* Observe their presence in the list
* Observe notifications arrive

* Use the bin icon to remove tracked items
* Observe items removed from list
* Observe lack of notifications

* Refresh page after waiting for 5 seconds
* Observe saved settings are reloaded

## Screenshots

Empty setup

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/119c3219-db8d-48df-ac3b-830e3923ae3d)

With items

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/e9130b9a-1022-4e3f-9524-50d592512348)
