### PR TITLE
Display item names instead of hrids in Loot Simulator

### DIFF
--- a/src/MooLite/plugins/LootSimulator/LootSimulatorPlugin.ts
+++ b/src/MooLite/plugins/LootSimulator/LootSimulatorPlugin.ts
@@ -7,6 +7,8 @@ import { MonsterDetail } from "src/MooLite/core/combat/monsters/MonsterDetail";
 import { ItemAmount } from "src/MooLite/core/inventory/items/ItemAmount";
 import { LootSimulator } from "src/MooLite/plugins/LootSimulator/LootSimulator";
 import { PluginAuthorCredits } from "src/MooLite/core/plugins/PluginAuthorCredits";
+import { ItemDetail } from "src/MooLite/core/inventory/items/ItemDetail";
+import { ItemHrid } from "src/MooLite/core/inventory/ItemHrid";
 
 export class LootSimulatorPlugin extends MooLitePlugin {
     name: string = "Loot Simulator";
@@ -27,6 +29,10 @@ export class LootSimulatorPlugin extends MooLitePlugin {
 
     public get allMonsters(): MonsterDetail[] {
         return this._game.combat.monsterDetailList;
+    }
+
+    public get itemDetailMap(): Record<ItemHrid, ItemDetail> {
+        return this._game.inventory.itemDetailMap;
     }
 
     simulate(monsterHrid: MonsterHrid, iterations: number): ItemAmount[] {

--- a/src/MooLite/plugins/LootSimulator/LootSimulatorPluginDisplay.vue
+++ b/src/MooLite/plugins/LootSimulator/LootSimulatorPluginDisplay.vue
@@ -32,7 +32,7 @@ const simulate = () => {
     <div class="flex flex-col gap-2">
         <span class="text-center">{{ plugin.name }}</span>
 
-        <MooDivider/>
+        <MooDivider />
 
         <select v-model="selectedHrid" class="bg-divider p-2 text-dark-mode">
             <option v-for="option in options" :value="option.value" class="bg-divider">

--- a/src/MooLite/plugins/LootSimulator/LootSimulatorPluginDisplay.vue
+++ b/src/MooLite/plugins/LootSimulator/LootSimulatorPluginDisplay.vue
@@ -2,6 +2,7 @@
 import { computed, Ref, ref } from "vue";
 import { LootSimulatorPlugin } from "src/MooLite/plugins/LootSimulator/LootSimulatorPlugin";
 import { ItemAmount } from "src/MooLite/core/inventory/items/ItemAmount";
+import MooDivider from "src/components/atoms/MooDivider.vue";
 
 const props = defineProps<{
     plugin: LootSimulatorPlugin;
@@ -28,22 +29,24 @@ const simulate = () => {
 </script>
 
 <template>
-    <div class="flex flex-col">
-        <span>Loot Simulator</span>
-        <select v-model="selectedHrid" class="bg-divider text-dark-mode">
+    <div class="flex flex-col gap-2">
+        <span class="text-center">{{ plugin.name }}</span>
+
+        <MooDivider/>
+
+        <select v-model="selectedHrid" class="bg-divider p-2 text-dark-mode">
             <option v-for="option in options" :value="option.value" class="bg-divider">
                 {{ option.text }}
             </option>
         </select>
 
-        <br />
-        <input class="bg-divider" type="number" v-model="iterations" />
+        <input class="bg-divider p-2 text-dark-mode" type="number" v-model="iterations" />
 
         <button @click="simulate">Simulate!</button>
 
         <div class="flex flex-col">
             <div v-for="drop in loot" class="flex flex-row justify-between">
-                <span>{{ drop.itemHrid }}</span>
+                <span>{{ plugin.itemDetailMap[drop.itemHrid].name }}</span>
                 <span>{{ drop.count }}</span>
             </div>
         </div>


### PR DESCRIPTION
## Overview

Item name is a much friendlier way of displaying what you've won from the simulator. This change will display the item name pulled from the detail map instead of the hrid. Also included are some layout and color tweaks to get closer to the Item Finder which is a bit more readable

## Screenshots

Before

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/edec71cb-421e-4902-9a31-d33412a7efa0)

After

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/10acfce8-5cc8-4a39-bcd1-904bfa1457ad)