### PR TITLE
Add theme tweaks

### DIFF
--- a/src/MooLite/plugins/Themes/ThemesPlugin.ts
+++ b/src/MooLite/plugins/Themes/ThemesPlugin.ts
@@ -7,6 +7,7 @@ import { ThemeHrid } from "src/MooLite/plugins/Themes/ThemeHrid";
 import strawberry from "./strawberry-kawa-chan.css?inline";
 import mint from "./mint-kawa-chan.css?inline";
 import banana from "./banana-kawa-chan.css?inline";
+import fixChatButtonBorder from "./fix-chat-button-border.css?inline";
 
 export class ThemesPlugin extends MooLitePlugin {
     name = "Themes";
@@ -35,6 +36,13 @@ export class ThemesPlugin extends MooLitePlugin {
                 { text: "Banana by Kawa-Chan", value: ThemeHrid.Banana },
             ],
         },
+        {
+            key: "enable-fix-chat-button-border",
+            name: "Fix chat button border",
+            description: "Squares off the left edge of the chat button",
+            type: PluginConfigType.CheckBox,
+            value: true,
+        },
     ];
 
     private readonly _themes: Record<ThemeHrid, string> = {
@@ -49,34 +57,59 @@ export class ThemesPlugin extends MooLitePlugin {
     }
 
     public onThemeChanged(themeName: ThemeHrid) {
-        // Clear the previous style
-        const previousStyle = document.getElementById(this.STYLE_ID);
-        if (previousStyle) {
-            document.head.removeChild(previousStyle);
-        }
-
         // And create a new style tag for the new one
         const theme = this._themes[themeName];
+        this.addCss(this.STYLE_ID, theme);
+    }
+
+    onEnableFixChatButtonBorderChanged(newValue: boolean) {
+        const styleId = `moolite-tweak-fix-chat-button-border`;
+        newValue ? this.addCss(styleId, fixChatButtonBorder) : this.removeCss(styleId);
+    }
+
+    addCss(styleId: string, css: string): void {
+        // Remove any existing CSS for this ID to avoid duplicated. This is
+        // preferable to checking and no-oping se we can overwrite the existing
+        // style.
+        this.removeCss(styleId);
+
         const style = document.createElement("style");
-        style.setAttribute("id", this.STYLE_ID);
-        style.appendChild(document.createTextNode(theme));
+        style.setAttribute("id", styleId);
+        style.appendChild(document.createTextNode(css));
         document.head.appendChild(style);
+    }
+
+    removeCss(styleId: string): void {
+        const style = document.getElementById(styleId);
+        if (style) {
+            document.head.removeChild(style);
+        }
     }
 
     enable() {
         super.enable();
         this.onThemeChanged(this.selectedTheme as ThemeHrid);
+        this.onEnableFixChatButtonBorderChanged(this.getConfig("enable-fix-chat-button-border").value);
     }
 
     disable() {
         super.disable();
         this.onThemeChanged(ThemeHrid.Default);
+        this.onEnableFixChatButtonBorderChanged(false);
     }
 
     public onConfigChange(key: string, newValue: any) {
+        // If the whole plugin is disabled, we shouldn't be changing what the
+        // theme looks like.
+        if (!this.isEnabled) {
+            return;
+        }
+
         switch (key) {
             case "selected-theme":
                 this.onThemeChanged(newValue as ThemeHrid);
+            case "enable-fix-chat-button-border":
+                this.onEnableFixChatButtonBorderChanged(newValue);
         }
     }
 }

--- a/src/MooLite/plugins/Themes/ThemesPlugin.ts
+++ b/src/MooLite/plugins/Themes/ThemesPlugin.ts
@@ -7,6 +7,7 @@ import { ThemeHrid } from "src/MooLite/plugins/Themes/ThemeHrid";
 import strawberry from "./strawberry-kawa-chan.css?inline";
 import mint from "./mint-kawa-chan.css?inline";
 import banana from "./banana-kawa-chan.css?inline";
+import fixChatButtonBorder from "./fix-chat-button-border.css?inline";
 
 export class ThemesPlugin extends MooLitePlugin {
     name = "Themes";
@@ -35,6 +36,13 @@ export class ThemesPlugin extends MooLitePlugin {
                 { text: "Banana by Kawa-Chan", value: ThemeHrid.Banana },
             ],
         },
+        {
+            key: "enable-fix-chat-button-border",
+            name: "Fix chat button border",
+            description: "Squares off the left edge of the chat button",
+            type: PluginConfigType.CheckBox,
+            value: true,
+        },
     ];
 
     private readonly _themes: Record<ThemeHrid, string> = {
@@ -48,35 +56,63 @@ export class ThemesPlugin extends MooLitePlugin {
         return this.getConfig("selected-theme").value;
     }
 
-    public onThemeChanged(themeName: ThemeHrid) {
-        // Clear the previous style
-        const previousStyle = document.getElementById(this.STYLE_ID);
-        if (previousStyle) {
-            document.head.removeChild(previousStyle);
+    private onThemeChanged(themeName: ThemeHrid) {
+        if (!this.isEnabled) {
+            return;
         }
 
         // And create a new style tag for the new one
         const theme = this._themes[themeName];
+        this.addCss(this.STYLE_ID, theme);
+    }
+
+    private onEnableFixChatButtonBorderChanged(newValue: boolean) {
+        if (!this.isEnabled) {
+            return;
+        }
+
+        const styleId = `moolite-tweak-fix-chat-button-border`;
+        newValue ? this.addCss(styleId, fixChatButtonBorder) : this.removeCss(styleId);
+    }
+
+    private addCss(styleId: string, css: string): void {
+        // Remove any existing CSS for this ID to avoid duplicated. This is
+        // preferable to checking and no-oping se we can overwrite the existing
+        // style.
+        this.removeCss(styleId);
+
         const style = document.createElement("style");
-        style.setAttribute("id", this.STYLE_ID);
-        style.appendChild(document.createTextNode(theme));
+        style.setAttribute("id", styleId);
+        style.appendChild(document.createTextNode(css));
         document.head.appendChild(style);
+    }
+
+    private removeCss(styleId: string): void {
+        const style = document.getElementById(styleId);
+        if (style) {
+            document.head.removeChild(style);
+        }
     }
 
     enable() {
         super.enable();
         this.onThemeChanged(this.selectedTheme as ThemeHrid);
+        this.onEnableFixChatButtonBorderChanged(this.getConfig("enable-fix-chat-button-border").value);
     }
 
     disable() {
         super.disable();
         this.onThemeChanged(ThemeHrid.Default);
+        this.onEnableFixChatButtonBorderChanged(false);
     }
 
     public onConfigChange(key: string, newValue: any) {
+        console.log({ key, newValue });
         switch (key) {
             case "selected-theme":
                 this.onThemeChanged(newValue as ThemeHrid);
+            case "enable-fix-chat-button-border":
+                this.onEnableFixChatButtonBorderChanged(newValue);
         }
     }
 }

--- a/src/MooLite/plugins/Themes/fix-chat-button-border.css
+++ b/src/MooLite/plugins/Themes/fix-chat-button-border.css
@@ -1,0 +1,5 @@
+.Chat_buttonContainer__1rw8b {
+    .Button_button__1Fe9z {
+        border-radius: 0 4px 4px 0;
+    }
+}

--- a/src/components/plugins/config/PluginConfigDisplay.vue
+++ b/src/components/plugins/config/PluginConfigDisplay.vue
@@ -19,14 +19,18 @@ const emit = defineEmits(["onConfigChange"]);
     <div class="flex flex-row">
         <span :title="config.description">{{ config.name }}</span>
         <span class="flex-1"></span>
-        <input v-if="config.type === PluginConfigType.CheckBox" type="checkbox" v-model="config.value" />
+        <input
+            v-if="config.type === PluginConfigType.CheckBox"
+            type="checkbox"
+            v-model="config.value"
+            @change="emit('onConfigChange')"
+        />
         <input
             v-if="config.type === PluginConfigType.Text"
             type="text"
             v-model="config.value"
             class="bg-divider w-24C text-dark-mode"
         />
-
         <select
             v-if="config.type === PluginConfigType.Choice"
             v-model="config.value"


### PR DESCRIPTION
## Overview

Based on https://discord.com/channels/891160051459436574/1205502683310727210/1205502683310727210

This change modifies the themes plugin to support adding other CSS tweaks. It's not super generic right now, but it's a decent example of modifying other parts of the UI.]

Also prevents the theme from being changed if the theme drop down is used while the plugin is disabled.

Idk if this is even the kind of thing you want to be in MooLite, but it only took 10 minutes to try it out

## Screenshots

Before

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/2aeb256b-c927-43dd-92f5-9753ce64e796)

After

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/3a89afac-2ae4-49e2-b1b7-5f79901514bd)
