### PR TITLE
Resubscribe to MooSocket after disconnection

### DIFF
--- a/src/MooLite/core/MooLite.ts
+++ b/src/MooLite/core/MooLite.ts
@@ -22,6 +22,7 @@ import { EquipmentBuffsUpdatedParser } from "src/MooLite/core/server/messages/Eq
 import { ItemsUpdatedParser } from "src/MooLite/core/server/messages/ItemsUpdated";
 import { LootOpenedParser } from "src/MooLite/core/server/messages/LootOpened";
 import { AbilitiesUpdatedParser } from "src/MooLite/core/server/messages/AbilitiesUpdated";
+import { unsafeWindow } from "$";
 
 export class MooLite {
     pluginManager: PluginManager;
@@ -59,14 +60,18 @@ export class MooLite {
         this.pluginManager = pluginManager;
         this.mooSocket = mooSocket;
 
-        this.mooSocket.onServerMessage.subscribe((message) => this.parseMessage(message, false));
-        this.mooSocket.onClientMessage.subscribe((message) => this.parseMessage(message, true));
+        this.subscribeToMooSocket();
 
         this._interval = setInterval(() => {
             this._clientTick(1);
         }, 1000);
 
         this._load();
+    }
+
+    private subscribeToMooSocket(): void {
+        this.mooSocket.onServerMessage.subscribe((message) => this.parseMessage(message, false));
+        this.mooSocket.onClientMessage.subscribe((message) => this.parseMessage(message, true));
     }
 
     private _timeSinceLastSave: number = 0;
@@ -78,6 +83,11 @@ export class MooLite {
         if (this._timeSinceLastSave > this.SAVE_INTERVAL) {
             this._save();
             this._timeSinceLastSave = 0;
+        }
+
+        if (unsafeWindow.mooSocket && this.mooSocket !== unsafeWindow.mooSocket) {
+            this.mooSocket = unsafeWindow.mooSocket;
+            this.subscribeToMooSocket();
         }
 
         this.pluginManager.clientTick();

--- a/src/MooLite/core/MooSocket.ts
+++ b/src/MooLite/core/MooSocket.ts
@@ -29,6 +29,8 @@ export class MooSocket extends WebSocket {
         if (url.toString().includes("milkyway")) {
             unsafeWindow.mooSocket = this;
         }
+
+        this.initialize();
     }
 
     public initialize(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,6 @@ const launchMooLite = () => {
         return;
     }
 
-    mooSocket.initialize();
     mooSocket.onInitClientInfoMessage.subscribe((clientInfo) => {
         // Create the game with the init client info
         const game = reactive<Game>(new Game(clientInfo)) as Game;


### PR DESCRIPTION
## Overview

https://github.com/Ishadijcks/MooLite/issues/86

If MWI drops it's WebSocket connection (e.g. by server restart or by calling `gameWebsocket.closeConnection()`) then it will create a new socket instead of reopening the old one. This obviously then causes MooLite to stop working as intended because we no longer receive any server updates.

When this change is applied, we will check if the MooLite socket is still the same as the socket that MWI is using, and if it's not then we'll reconnect and resubscribe. The check is happening in the tick handler so it shouldn't be a big performance impact.

## Testing instructions

* Open the XP tracker plugin
* Start milking cows
* Observe the tracker increasing your milking xp
* Open console and run `gameWebsocket.closeConnection()`
* You should get the `Attempting to connect` screen, followed by MWI reloading
* Observe the XP tracker is still counting (without this commit, it will not resume after disconnecting)