### PR TITLE
Add config to display MooLite on the left of the screen

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,7 @@ if (findPlugin("MooLite").getConfig("mooliteclient/start-collapsed").value === t
     <div class="flex flex-col h-full shadow-sm overflow-clip bg-background-game text-dark-mode shadow-space-200">
         <MooDivider class="border-b-4" />
 
-        <div class="flex flex-row h-full">
+        <div id="moolite-container" class="flex flex-row h-full">
             <div v-if="activeTab > -1" class="flex flex-col flex-grow p-2 overflow-auto">
                 <PluginManagerDisplay
                     v-if="activeTab === 0"

--- a/src/MooLite/util/String.ts
+++ b/src/MooLite/util/String.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts an input string to title case.
+ *
+ * e.g.
+ * `word` => `Word`
+ * `small text` => `Small Text`
+ *
+ * @param input string to format to title case
+ * @returns the input string formatted to title case
+ */
+export function toTitleCase(input: string): string {
+    return input.replace(/\w\S*/g, (part) => {
+        return part.charAt(0).toUpperCase() + part.substr(1).toLowerCase();
+    });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,12 +74,14 @@ const launchMooLite = () => {
             (() => {
                 const app = document.createElement("div");
                 const root = document.getElementById("root");
+
                 if (root == null) {
                     throw new Error("Could not append MooLite to the element with id 'root' as it does not exist");
                 }
+
                 root.append(app);
                 root.style.setProperty("display", "flex");
-                root.style.setProperty("flex-direction", "row");
+
                 return app;
             })()
         );


### PR DESCRIPTION
## Overview

https://github.com/Ishadijcks/MooLite/issues/138

When this change is applied, the MooLite plugin will have an additional config option for display side, which can be set to either left or right. Right will remain the default, and left will display on the other side using the magic of flex display to render backwards.

## Testing instructions

* Open MooLite plugin
* Change display side

## Screenshots

Right

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/67d12ec1-2c2a-436f-aaa0-5248d66da209)

Left

![image](https://github.com/Ishadijcks/MooLite/assets/9394863/1fd0f33b-f801-4585-8781-ae6b78e2b5af)